### PR TITLE
Add recursive sort function for ARM templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,11 @@ If no output file path is given, the output will be send to `stdout`
 
 ## Changelog
 
+### v2.2.0
+
+* FEATURE: Sort all properties in the resulting JSON file by property name. \
+  This allows to use the resulting JSON/ARM file to be used in any CI/CD pipeline without commits based on sort order.
+
 ### v2.1.0
 
 * FIX: Fixed major flaw in conversion that could corrupt YAML files because of wrong Name translation. \

--- a/src/SentinelARConverter.psd1
+++ b/src/SentinelARConverter.psd1
@@ -12,7 +12,7 @@
     RootModule        = 'SentinelARConverter.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '2.1.0'
+    ModuleVersion     = '2.2.0'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/src/SentinelARConverter.psm1
+++ b/src/SentinelARConverter.psm1
@@ -1,8 +1,8 @@
 # Import private and public scripts and expose the public ones
-$privateScripts = @(Get-ChildItem -Path "$PSScriptRoot\private" -Recurse -Filter "*.ps1") | Sort-Object Name
-$publicScripts = @(Get-ChildItem -Path "$PSScriptRoot\public" -Recurse -Filter "*.ps1") | Sort-Object Name
+$privateScripts = @(Get-ChildItem -Path "$PSScriptRoot\private" -Recurse -Filter "*.ps1" | Sort-Object Name )
+$publicScripts = @(Get-ChildItem -Path "$PSScriptRoot\public" -Recurse -Filter "*.ps1" | Sort-Object Name )
 
-foreach ($script in ($privateScripts + $publicScripts)) {
+foreach ($script in @($privateScripts + $publicScripts)) {
     Write-Verbose $script
     try {
         . $script.FullName

--- a/src/private/Invoke-SortJSONObject.ps1
+++ b/src/private/Invoke-SortJSONObject.ps1
@@ -1,0 +1,32 @@
+function Invoke-SortJSONObject {
+    param (
+        [Parameter()]
+        $object
+    )
+
+    if ($object -is [PSCustomObject]) {
+        $hash = [ordered]@{}
+        foreach ($property in $object.PSObject.Properties | Sort-Object Name) {
+            if ($property.TypeNameOfValue -eq "System.Object[]" -or $property -is [System.Collections.ArrayList]) {
+                $hash[$property.Name] = @(Invoke-SortJSONObject $property.Value)
+            } else {
+                $hash[$property.Name] = Invoke-SortJSONObject $property.Value
+            }
+        }
+        return $hash
+    } elseif ($object -is [System.Collections.IDictionary]) {
+        $hash = [ordered]@{}
+        foreach ($key in $object.Keys | Sort-Object) {
+            $hash[$key] = Invoke-SortJSONObject $object[$key]
+        }
+        return $hash
+    } elseif ($object -is [System.Collections.IEnumerable] -and $object -isnot [string]) {
+        $array = @()
+        foreach ($item in $object) {
+            $array += Invoke-SortJSONObject $item
+        }
+        return $array
+    } else {
+        return $object
+    }
+}

--- a/src/public/Convert-SentinelARYamlToArm.ps1
+++ b/src/public/Convert-SentinelARYamlToArm.ps1
@@ -253,17 +253,8 @@ function Convert-SentinelARYamlToArm {
             }
         }
 
-        # Sort by custom order
-        $ARMTemplateOrdered = [ordered]@{}
-        $ErrorActionPreference = "SilentlyContinue"
-        $AnalyticsRuleKeys = $ARMTemplate.Keys | Sort-Object { $i = $DefaultSortOrderInArmTemplate.IndexOf($_) ; if ( $i -eq -1 ) { 100 } else { $i } }
-        $ErrorActionPreference = "Continue"
-        foreach ($PropertyName in $AnalyticsRuleKeys) {
-            $ARMTemplateOrdered.Add($PropertyName, $ARMTemplate.$PropertyName)
-        }
-
         # Convert hashtable to JSON
-        $JSON = $ARMTemplateOrdered | ConvertTo-Json -Depth 99
+        $JSON = $ARMTemplate | ConvertTo-Json -Depth 99
         # Use ISO8601 format for timespan values
         $JSON = $JSON -replace '"([0-9]+)m"', '"PT$1M"' -replace '"([0-9]+)h"', '"PT$1H"' -replace '"([0-9]+)d"', '"P$1D"'
 
@@ -278,10 +269,10 @@ function Convert-SentinelARYamlToArm {
         $Result = $Template.Replace("<PROPERTIES>", $JSON)
         $Result = $Result.Replace("<TEMPLATEID>", $analyticRule.id)
         $Result = $Result.Replace("<RULEKIND>", $ScheduleKind)
-        if ( $PSVersionTable.PSVersion -ge [version]'7.0.0' ) {
-            # Beautify in PowerShell 7 and above
-            $Result = $Result | ConvertFrom-Json | ConvertTo-Json -Depth 99
-        }
+
+        # Sort all property keys in ARM template and convert to JSON string object
+        $Result = Invoke-SortJSONObject -object ( $Result | ConvertFrom-Json )
+        $Result = $Result | ConvertTo-Json -Depth 99
 
         if ($OutFile) {
             $Result | Out-File $OutFile -Force

--- a/src/public/Convert-SentinelARYamlToArm.ps1
+++ b/src/public/Convert-SentinelARYamlToArm.ps1
@@ -120,6 +120,12 @@ function Convert-SentinelARYamlToArm {
             throw "Analytics Rule name or id is empty. YAML might be corrupted"
         }
 
+        # Generate new guid if id is not a valid guid
+        if ($analyticRule.id -notmatch "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}") {
+            Write-Warning "Error reading current Id. Generating new Id."
+            $analyticRule.id = (New-Guid).Guid
+        }
+
         Write-Verbose "Convert Analytics Rule $($analyticRule.name) ($($analyticRule.id)) to ARM template"
 
         #region Set output filename to defined value if not specified by user

--- a/src/public/Convert-SentinelARYamlToArm.ps1
+++ b/src/public/Convert-SentinelARYamlToArm.ps1
@@ -174,30 +174,6 @@ function Convert-SentinelARYamlToArm {
         # Replace API version with specified version
         $Template = $Template.Replace('<APIVERSION>', $APIVersion)
 
-        # Only include the following keys in ARM template
-        $DefaultSortOrderInArmTemplate = @(
-            "displayName",
-            "description",
-            "severity",
-            "enabled",
-            "query",
-            "queryFrequency",
-            "queryPeriod",
-            "triggerOperator",
-            "triggerThreshold",
-            "suppressionDuration",
-            "suppressionEnabled",
-            "tactics",
-            "techniques",
-            "alertRuleTemplateName",
-            "incidentConfiguration",
-            "eventGroupingSettings",
-            "alertDetailsOverride",
-            "customDetails",
-            "entityMappings",
-            "sentinelEntitiesMappings"
-        )
-
         $SkipYamlValues = @(
             "metadata",
             "kind",


### PR DESCRIPTION
Add recursive sort function for ARM templates to keep resulting ARM template files in same order to avoid unnecessary Git commits because of changed order of properties.

Fix ARM template creation with invalid GUID as id