### PR TITLE
Add new parameter NamePrefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ If no output file path is given, the output will be send to `stdout`
 
 ## Changelog
 
+### v2.2.1
+
+ * FEATURE: Add new parameter `-NamePrefix` for `Convert-SentinelARYamlToArm` to allow the user to add a prefix to the ANR name
+
 ### v2.2.0
 
 * FEATURE: Sort all properties in the resulting JSON file by property name. \

--- a/src/SentinelARConverter.psd1
+++ b/src/SentinelARConverter.psd1
@@ -12,7 +12,7 @@
     RootModule        = 'SentinelARConverter.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '2.2.0'
+    ModuleVersion     = '2.2.1'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/src/public/Convert-SentinelARYamlToArm.ps1
+++ b/src/public/Convert-SentinelARYamlToArm.ps1
@@ -31,6 +31,9 @@ The extension will be replaced with .json
 .PARAMETER APIVersion
 Set API version of the ARM template. Default is "2022-11-01-preview"
 
+.PARAMETER NamePrefix
+Set prefix for the name of the ARM template. Default is none
+
 .EXAMPLE
 Convert-SentinelARYamlToArm -Filename "C:\Temp\MyRule.yaml" -OutFile "C:\Temp\MyRule.json"
 
@@ -80,7 +83,10 @@ function Convert-SentinelARYamlToArm {
 
         [ValidatePattern('^\d{4}-\d{2}-\d{2}(-preview)?$')]
         [Parameter()]
-        [string]$APIVersion = "2022-11-01-preview"
+        [string]$APIVersion = "2022-11-01-preview",
+
+        [Parameter()]
+        [string]$NamePrefix
     )
 
     begin {
@@ -124,6 +130,11 @@ function Convert-SentinelARYamlToArm {
         if ($analyticRule.id -notmatch "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}") {
             Write-Warning "Error reading current Id. Generating new Id."
             $analyticRule.id = (New-Guid).Guid
+        }
+
+        # Add prefix to name if specified
+        if ($NamePrefix) {
+            $analyticRule.name = $NamePrefix + $analyticRule.name
         }
 
         Write-Verbose "Convert Analytics Rule $($analyticRule.name) ($($analyticRule.id)) to ARM template"

--- a/tests/Convert-SentinelARYamlToArm.tests.ps1
+++ b/tests/Convert-SentinelARYamlToArm.tests.ps1
@@ -228,6 +228,30 @@ Describe "Convert-SentinelARYamlToArm" {
         }
     }
 
+    Context "Scheduled with parameter NamePrefix" -Tag Integration {
+        BeforeAll {
+            Copy-Item -Path $exampleScheduledFilePath -Destination "TestDrive:/Scheduled.yaml" -Force
+            $NamePrefix = "TestPrefix "
+            Convert-SentinelARYamlToArm -Filename "TestDrive:/Scheduled.yaml" -OutFile "TestDrive:/Scheduled.json" -NamePrefix $NamePrefix
+            $armTemplate = Get-Content -Path "TestDrive:/Scheduled.json" -Raw | ConvertFrom-Json
+        }
+
+        AfterEach {
+            if ( -not $RetainTestFiles) {
+                Remove-Item -Path "TestDrive:/*" -Include *.json -Force
+            }
+        }
+
+        It "Should have the prefix at the start of the displayname" {
+            $armTemplate.resources[0].properties.displayName | Should -Match "^TestPrefix "
+        }
+
+        It "Should have the prefix at the start of the displayname" {
+            $armTemplate.resources[0].properties.displayName | Should -Be "TestPrefix Azure WAF matching for Log4j vuln(CVE-2021-44228)"
+        }
+    }
+
+
     AfterAll {
         Remove-Module SentinelARConverter -Force
     }


### PR DESCRIPTION
* FEATURE: Add new parameter `-NamePrefix` for `Convert-SentinelARYamlToArm` to allow the user to add a prefix to the ANR name