### PR TITLE
Add DisableIncidentCreation parameter and test case

### DIFF
--- a/src/SentinelARConverter.psd1
+++ b/src/SentinelARConverter.psd1
@@ -12,7 +12,7 @@
     RootModule        = 'SentinelARConverter.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '2.2.3'
+    ModuleVersion     = '2.2.4'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/tests/Convert-SentinelARYamlToArm.tests.ps1
+++ b/tests/Convert-SentinelARYamlToArm.tests.ps1
@@ -375,6 +375,24 @@ Describe "Convert-SentinelARYamlToArm" {
         }
     }
 
+    Context "Scheduled with disabled incident creation" {
+        BeforeAll {
+            Copy-Item -Path $exampleScheduledFilePath -Destination "TestDrive:/Scheduled.yaml" -Force
+            Convert-SentinelARYamlToArm -Filename "TestDrive:/Scheduled.yaml" -OutFile "TestDrive:/Scheduled.json" -DisableIncidentCreation
+            $armTemplate = Get-Content -Path "TestDrive:/Scheduled.json" -Raw | ConvertFrom-Json
+        }
+
+        AfterEach {
+            if ( -not $RetainTestFiles) {
+                Remove-Item -Path "TestDrive:/*" -Include *.json -Force
+            }
+        }
+
+        It "Should have the incident creation disabled" {
+            $armTemplate.resources[0].properties.incidentConfiguration.createIncident | Should -Be $false
+        }
+    }
+
     AfterAll {
         Remove-Module SentinelARConverter -Force
     }


### PR DESCRIPTION
This pull request adds a new parameter called DisableIncidentCreation to the Convert-SentinelARYamlToArm.ps1 script. It also includes a test case for disabling incident creation in the scheduled YAML conversion. Additionally, the module version is updated to 2.2.4.