### PR TITLE
Add IncludeRequiredDataConnectors,OmitDataTypeExtension - requiredDataConnectors to ARM template

### DIFF
--- a/src/public/Convert-SentinelARYamlToArm.ps1
+++ b/src/public/Convert-SentinelARYamlToArm.ps1
@@ -245,6 +245,12 @@ function Convert-SentinelARYamlToArm {
         # Replace API version with specified version
         $Template = $Template.Replace('<APIVERSION>', $APIVersion)
 
+        $SkipYamlValues = @(
+            "metadata",
+            "kind",
+            "requiredDataConnectors"
+        )
+
         # Only include the following keys in ARM template
         $DefaultSortOrderInArmTemplate = @(
             "displayName",

--- a/src/public/Convert-SentinelARYamlToArm.ps1
+++ b/src/public/Convert-SentinelARYamlToArm.ps1
@@ -251,30 +251,6 @@ function Convert-SentinelARYamlToArm {
             "requiredDataConnectors"
         )
 
-        # Only include the following keys in ARM template
-        $DefaultSortOrderInArmTemplate = @(
-            "displayName",
-            "description",
-            "severity",
-            "enabled",
-            "query",
-            "queryFrequency",
-            "queryPeriod",
-            "triggerOperator",
-            "triggerThreshold",
-            "suppressionDuration",
-            "suppressionEnabled",
-            "tactics",
-            "techniques",
-            "alertRuleTemplateName",
-            "incidentConfiguration",
-            "eventGroupingSettings",
-            "alertDetailsOverride",
-            "customDetails",
-            "entityMappings",
-            "sentinelEntitiesMappings"
-        )
-
         # Mapping of Arm template names to YAML name when different
         $ValueNameMappingYaml2Arm = [ordered]@{
             "name"               = "displayName"

--- a/tests/examples/yamlwithRequiredMultiple.yaml
+++ b/tests/examples/yamlwithRequiredMultiple.yaml
@@ -1,0 +1,88 @@
+tactics:
+  - ImpairProcessControl
+id: 70be4a31-9d2b-433b-bdc7-da8928988069
+kind: Scheduled
+requiredDataConnectors:
+  - dataTypes:
+      - SecurityAlert (ASC for IoT)
+    connectorId: IoT
+  - dataTypes:
+      - SomeOtherDataType
+      - SecurityAlert (ASC for IoT)
+    connectorId: IoT
+entityMappings:
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: SourceDeviceAddress
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: DestDeviceAddress
+status: Available
+relevantTechniques:
+  - T0855
+triggerThreshold: 0
+query: |
+  let alertList = dynamic(["Function Code Not Supported by Outstation", "Illegal BACNet message", "Illegal Connection Attempt on Port 0", "Illegal DNP3 Operation", "Illegal MODBUS Operation (Exception Raised by Master)",  "Illegal MODBUS Operation (Function Code Zero)", "Incorrect Parameter Sent to Outstation", "Initiation of an Obsolete Function Code (Initialize Data)", "Initiation of an Obsolete Function Code (Save Config)", "Modbus Exception", "Unknown Object Sent to Outstation", "Usage of a Reserved Function Code",  "Usage of Improper Formatting by Outstation", "Usage of Reserved Status Flags (IIN)", "Unauthorized communication was detected by a User Defined Protocol Rule", "Unauthorized Operation was detected by a User Defined whitelist Alert", "Illegal Protocol Version", "New Activity Detected - LonTalk Network Variable", "New Activity Detected - Ovation Data Request", "New Activity Detected - Read/Write Command (AMS Index Group)", "New Activity Detected - Read/Write Command (AMS Index Offset)", "New Activity Detected - Unauthorized DeltaV Message Type", "New Activity Detected - Unauthorized DeltaV ROC Operation", "New Activity Detected - Using AMS Protocol Command", "New Activity Detected - Using Siemens SICAM Command", "New Activity Detected - Using Suitelink Protocol command", "New Activity Detected - Using Suitelink Protocol sessions", "New Activity Detected - Using Yokogawa VNetIP Command", "Omron FINS Unauthorized Command", "Toshiba Computer Link Unauthorized Command", "Unauthorized ABB Totalflow File Operation", "Unauthorized ABB Totalflow Register Operation", "Unauthorized Access to Siemens S7 Plus Object", "Unauthorized BACNet Object Access", "Unauthorized BACNet Route", "Unauthorized Emerson ROC Operation", "Unauthorized GE SRTP File Access", "Unauthorized GE SRTP Protocol Command", "Unauthorized GE SRTP System Memory Operation", "Unauthorized Mitsubishi MELSEC Command", "Unauthorized MMS Service", "Unauthorized OPC UA Activity", "Unauthorized OPC UA Request/Response", "Unauthorized Profinet Frame Type", "Unauthorized SAIA S-Bus Command", "Unauthorized Siemens S7 Execution of Control Function", "Unauthorized Siemens S7 Execution of User Defined Function", "Unauthorized Siemens S7 Plus Block Access", "Unauthorized Siemens S7 Plus Operation", "Unauthorized SNMP Operation", "Unpermitted Modbus Schneider Electric Extension", "Unpermitted Usage of ASDU Types", "Unpermitted Usage of DNP3 Function Code", "Unpermitted Usage of Modbus Function Code", "Unauthorized Operation was detected by a User Defined Rule", "Unauthorized PLC Configuration Read", "Unauthorized PLC Programming", "Unauthorized PLC Configuration Write", "Unauthorized PLC Program Upload", "Slave Device Received Illegal"]);
+  SecurityAlert
+  | where ProviderName == "IoTSecurity"
+  | where AlertName has_any (alertList)
+  | extend ExtendedProperties = parse_json(ExtendedProperties)
+  | where tostring(ExtendedProperties.isNew) == "True"
+  | extend DeviceId = tostring(ExtendedProperties.DeviceId), 
+           SourceDeviceAddress = tostring(ExtendedProperties.SourceDeviceAddress), 
+           DestDeviceAddress = tostring(ExtendedProperties.DestinationDeviceAddress), 
+           RemediationSteps = tostring(parse_json(RemediationSteps)[0]), 
+           Protocol = tostring(ExtendedProperties.Protocol), 
+           AlertManagementUri = tostring(ExtendedProperties.AlertManagementUri)
+  | project
+    TimeGenerated,
+    DeviceId,
+    ProductName,
+    ProductComponentName,
+    AlertSeverity,
+    AlertName,
+    Description,
+    Protocol,
+    SourceDeviceAddress,
+    DestDeviceAddress,
+    RemediationSteps,
+    Tactics,
+    Entities,
+    VendorOriginalId,
+    AlertLink,
+    AlertManagementUri,
+    Techniques
+triggerOperator: gt
+description: |
+  'This alert leverages Defender for IoT to detect Illegal function codes in SCADA equipment indicating improper application configuration or malicious activity such using illegal values within a protocol to exploit a PLC vulnerability.'
+version: 1.0.2
+queryPeriod: 1h
+customDetails:
+  AlertManagementUri: AlertManagementUri
+  VendorOriginalId: VendorOriginalId
+  Sensor: DeviceId
+  Protocol: Protocol
+severity: Medium
+eventGroupingSettings:
+  aggregationKind: AlertPerResult
+queryFrequency: 1h
+alertDetailsOverride:
+  alertDescriptionFormat: (MDIoT) {{Description}}
+  alertSeverityColumnName: AlertSeverity
+  alertDynamicProperties:
+    - value: ProductName
+      alertProperty: ProductName
+    - value: RemediationSteps
+      alertProperty: RemediationSteps
+    - value: Techniques
+      alertProperty: Techniques
+    - value: ProductComponentName
+      alertProperty: ProductComponentName
+    - value: AlertLink
+      alertProperty: AlertLink
+  alertTacticsColumnName: Tactics
+  alertDisplayNameFormat: (MDIoT) {{AlertName}}
+name: Illegal Function Codes for ICS traffic (Microsoft Defender for IoT)
+OriginalUri: https://github.com/Azure/Azure-Sentinel/blob/master/Solutions/IoTOTThreatMonitoringwithDefenderforIoT/Analytic Rules/IoTIllegalFunctionCodes.yaml


### PR DESCRIPTION
Adds requiredDataConnectors back to the ARM template - I use it to validate the workspace prior to deployment whether it contains required tables/columns. 

## IncludeRequiredDataConnectors

Switch to include requiredDataConnectors to the ARM template when converting from yaml

## OmitDataTypeExtension

Removes the stuff inside of () and the brackets themselves - as this is not a table name - useless for me, opt in, not default behaviour.

## Exec w/ -OmitDataTypeExtension and -IncludeRequiredDataConnectors

![image](https://github.com/f-bader/SentinelARConverter/assets/62133917/ffb8417d-469d-4148-a279-2dfddac33709)

## Exec w/ -IncludeRequiredDataConnectors

![image](https://github.com/f-bader/SentinelARConverter/assets/62133917/4fe19d76-0f8d-4648-9b16-6fcf6bd6420c)

