### PR TITLE
Add support for scheduled YAML conversion with parameter file

### DIFF
--- a/src/SentinelARConverter.psd1
+++ b/src/SentinelARConverter.psd1
@@ -12,7 +12,7 @@
     RootModule        = 'SentinelARConverter.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '2.2.4'
+    ModuleVersion     = '2.3.0'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/src/public/Convert-SentinelARYamlToArm.ps1
+++ b/src/public/Convert-SentinelARYamlToArm.ps1
@@ -175,6 +175,9 @@ function Convert-SentinelARYamlToArm {
                     if ($analyticRule.ContainsKey($Key)) {
                         Write-Verbose "Overwriting property $Key with $($Parameters.OverwriteProperties[$Key])"
                         $analyticRule[$Key] = $Parameters.OverwriteProperties[$Key]
+                    } else {
+                        Write-Verbose "Add new property $Key with $($Parameters.OverwriteProperties[$Key])"
+                        $analyticRule.Add($Key, $Parameters.OverwriteProperties[$Key])
                     }
                 }
             } else {

--- a/tests/Convert-SentinelARYamlToArm.tests.ps1
+++ b/tests/Convert-SentinelARYamlToArm.tests.ps1
@@ -419,6 +419,10 @@ Describe "Convert-SentinelARYamlToArm" {
             $armTemplate.resources.properties.description | Should -Match "'403' or '404'"
         }
 
+        It "Should have all new properties from parameter file" {
+            $armTemplate.resources.properties.customDetails | Should -Not -BeNullOrEmpty
+        }
+
         It "Should have the correct added query values" {
             $armTemplate.resources.properties.query | Should -Match "// Example description. Will be added to the beginning of the query."
             $armTemplate.resources.properties.query | Should -Match "// Example text that will be added to the end of the query."

--- a/tests/Convert-SentinelARYamlToArm.tests.ps1
+++ b/tests/Convert-SentinelARYamlToArm.tests.ps1
@@ -12,6 +12,12 @@ param(
     [String]
     $exampleScheduledTTPFilePath = "./tests/examples/TTPWithTacticsNTechniques.yaml",
     [Parameter()]
+    [String]
+    $exampleScheduledWithVariablesFilePath = "./tests/examples/ScheduledParam.yaml",
+    [Parameter()]
+    [String]
+    $exampleScheduledParameterFilePath = "./tests/examples/ScheduledParam.params.yaml",
+    [Parameter()]
     [Switch]
     $RetainTestFiles = $false
 )
@@ -390,6 +396,37 @@ Describe "Convert-SentinelARYamlToArm" {
 
         It "Should have the incident creation disabled" {
             $armTemplate.resources[0].properties.incidentConfiguration.createIncident | Should -Be $false
+        }
+    }
+
+    Context "Scheduled with parameter file provided" {
+        BeforeAll {
+            Copy-Item -Path $exampleScheduledWithVariablesFilePath -Destination "TestDrive:/Scheduled.yaml" -Force
+            Copy-Item -Path $exampleScheduledParameterFilePath -Destination "TestDrive:/ScheduledParam.params.yaml" -Force
+            Convert-SentinelARYamlToArm -Filename "TestDrive:/Scheduled.yaml" -OutFile "TestDrive:/Scheduled.json" -ParameterFile "TestDrive:/ScheduledParam.params.yaml"
+            $armTemplate = Get-Content -Path "TestDrive:/Scheduled.json" -Raw | ConvertFrom-Json
+        }
+
+        AfterEach {
+            if ( -not $RetainTestFiles) {
+                Remove-Item -Path "TestDrive:/*" -Include *.json -Force
+            }
+        }
+
+        It "Should have the correct replaced parameter values" {
+            $armTemplate.resources.properties.queryPeriod | Should -Be "PT1H"
+            $armTemplate.resources.properties.queryFrequency | Should -Be "PT1H"
+            $armTemplate.resources.properties.description | Should -Match "'403' or '404'"
+        }
+
+        It "Should have the correct added query values" {
+            $armTemplate.resources.properties.query | Should -Match "// Example description. Will be added to the beginning of the query."
+            $armTemplate.resources.properties.query | Should -Match "// Example text that will be added to the end of the query."
+        }
+
+        It "Should have the correct variables replaced" {
+            $armTemplate.resources.properties.query | Should -Match 'where Message in \("403","404"\)'
+            $armTemplate.resources.properties.query | Should -Match 'where NumberOfErrors > 200'
         }
     }
 

--- a/tests/examples/ScheduledParam.params.yaml
+++ b/tests/examples/ScheduledParam.params.yaml
@@ -1,0 +1,16 @@
+OverwriteProperties:
+  description: |-
+    Identifies instances where Wazuh logged over 200 '403' or '404' Web Errors from one IP Address.
+    To onboard Wazuh data into Sentinel please view: https://github.com/wazuh/wazuh-documentation/blob/master/source/azure/monitoring%20activity.rst
+  queryFrequency: 1h
+  queryPeriod: 1h
+PrependQuery: |
+  // Example description. Will be added to the beginning of the query.
+AppendQuery: |
+  // Example text that will be added to the end of the query.
+  | extend TimeGenerated = StartTime
+ReplaceQueryVariables:
+  NumberOfErrors: 200
+  ErrorCodes:
+    - "403"
+    - "404"

--- a/tests/examples/ScheduledParam.params.yaml
+++ b/tests/examples/ScheduledParam.params.yaml
@@ -4,6 +4,8 @@ OverwriteProperties:
     To onboard Wazuh data into Sentinel please view: https://github.com/wazuh/wazuh-documentation/blob/master/source/azure/monitoring%20activity.rst
   queryFrequency: 1h
   queryPeriod: 1h
+  customDetails:
+    HostName: HostName
 PrependQuery: |
   // Example description. Will be added to the beginning of the query.
 AppendQuery: |
@@ -12,5 +14,5 @@ AppendQuery: |
 ReplaceQueryVariables:
   NumberOfErrors: 200
   ErrorCodes:
-    - "403"
+    - 403
     - "404"

--- a/tests/examples/ScheduledParam.yaml
+++ b/tests/examples/ScheduledParam.yaml
@@ -1,0 +1,42 @@
+id: 2790795b-7dba-483e-853f-44aa0bc9c985
+name: Wazuh - Large Number of Web errors from an IP
+description: |
+  'Identifies instances where Wazuh logged over 400 '403' Web Errors from one IP Address. To onboard Wazuh data into Sentinel please view: https://github.com/wazuh/wazuh-documentation/blob/master/source/azure/monitoring%20activity.rst'
+severity: Low
+requiredDataConnectors: []
+queryFrequency: 1d
+queryPeriod: 1d
+triggerOperator: gt
+triggerThreshold: 0
+tactics:
+  - Persistence
+query: |
+  CommonSecurityLog
+  | where DeviceProduct =~ "Wazuh"
+  | where Activity has "Web server 400 error code."
+  | where Message in (%%ErrorCodes%%)
+  | extend HostName=substring(split(DeviceCustomString1,")")[0],1)
+  | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated), NumberOfErrors = dcount(SourceIP) by HostName, SourceIP
+  | where NumberOfErrors > %%NumberOfErrors%%
+  | sort by NumberOfErrors desc
+  | extend timestamp = StartTime
+entityMappings:
+  - entityType: Host
+    fieldMappings:
+      - identifier: HostName
+        columnName: HostName
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: SourceIP
+version: 1.0.3
+kind: Scheduled
+metadata:
+  source:
+    kind: Community
+  author:
+    name: Jordan Ross
+  support:
+    tier: Community
+  categories:
+    domains: ["Security - Others", "Networking"]


### PR DESCRIPTION
This pull request adds support for scheduled YAML conversion with a parameter file. It includes the following changes:

- The module version is updated to 2.3.0.

- New feature to support a parameter file are added to the Convert-SentinelARYamlToArm.ps1 script.

- Documentation is updated to reflect the support for scheduled YAML conversion with a parameter file.