### PR TITLE
:bug: Rename techniques to relevantTechniques

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,9 @@ This way the following KQL query will be converted...
 
 ## Changelog
 
+### 2.4.2
+ * FIX: Arm to YAML used `techniques` instead of `relevantTechniques`
+
 ### 2.4.1
  * FIX: Handle error if `incidentConfiguration` section is missing from source YAML in `Convert-SentinelARYamlToArm` when using `-DisableIncidentCreation`
 

--- a/src/SentinelARConverter.psd1
+++ b/src/SentinelARConverter.psd1
@@ -12,7 +12,7 @@
     RootModule        = 'SentinelARConverter.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '2.4.1'
+    ModuleVersion     = '2.4.2'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/src/public/Convert-SentinelARArmToYaml.ps1
+++ b/src/public/Convert-SentinelARArmToYaml.ps1
@@ -347,7 +347,7 @@ function Convert-SentinelARArmToYaml {
                     # We must merge all techniques since (relevant)techniques could contain values not preset in subTechniques
                     if ($PropertyName -like "*techniques") {
                         foreach ($value in $AnalyticsRule.$PropertyName) {
-                            $KeyName = "techniques"
+                            $KeyName = "relevantTechniques"
                             $technique = $value -replace "(T\d{4})\.\d{3}", '$1'
                             # Create an empty key
                             if ( -not $AnalyticsRuleCleaned.Contains($KeyName) ) {

--- a/tests/Convert-SentinelARArmToYaml.tests.ps1
+++ b/tests/Convert-SentinelARArmToYaml.tests.ps1
@@ -133,8 +133,7 @@ Describe "Convert-SentinelARArmToYaml" {
         }
 
         BeforeEach {
-            $ARMTemplateContent = Get-Content -Path "TestDrive:/$ExampleFileName" -Raw
-            $ARMTemplateContent | Convert-SentinelARArmToYaml -OutFile $convertedExampleFilePath
+            Convert-SentinelARArmToYaml -Filename "TestDrive:/$ExampleFileName" -OutFile $convertedExampleFilePath
         }
 
         It "Properly converts the propertynames" {
@@ -589,7 +588,7 @@ Describe "Simple example tests" {
         It "Merged RelevantTechniques, SubTechniques and Techniques into single property" {
             $converted = Convert-SentinelARArmToYaml -Filename "TestDrive:/Content/TTPWithTacticsNTechniques.json" | ConvertFrom-Yaml
             $converted.subTechniques | Should -Be $null
-            $converted.Techniques -join ", " | Should -Be "T1078.003, T1078.004"
+            $converted.RelevantTechniques -join ", " | Should -Be "T1078.003, T1078.004"
         }
     }
 }

--- a/tests/examples/Scheduled.json
+++ b/tests/examples/Scheduled.json
@@ -1,4 +1,3 @@
-
 {
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
@@ -30,7 +29,9 @@
                 "tactics": [
                     "InitialAccess"
                 ],
-                "techniques": [],
+                "techniques": [
+                    "T1078"
+                ],
                 "alertRuleTemplateName": "2de8abd6-a613-450e-95ed-08e503369fb3",
                 "incidentConfiguration": {
                     "createIncident": true,


### PR DESCRIPTION
Fixes an issue where the `techniques` property was incorrectly named as `relevantTechniques` in the Arm to YAML conversion. This commit renames the property to `relevantTechniques` to ensure consistency and accuracy.

:test_tube: Ensure relevantTechniques

Adds a test to ensure that the `relevantTechniques` property is properly merged and converted during the Arm to YAML conversion process.

:memo: Bump version and release notes