### PR TITLE
Fix JSON formatting for escaped backslashes

### DIFF
--- a/src/public/Convert-SentinelARYamlToArm.ps1
+++ b/src/public/Convert-SentinelARYamlToArm.ps1
@@ -417,6 +417,8 @@ function Convert-SentinelARYamlToArm {
         # Use ISO8601 format for timespan values
         $JSON = $JSON -replace '"([0-9]+)m"', '"PT$1M"' -replace '"([0-9]+)h"', '"PT$1H"' -replace '"([0-9]+)d"', '"P$1D"'
 
+        $JSON = $JSON -replace '\\\\\\\"', '\"'
+
         if ($analyticRule.kind -eq "Scheduled") {
             $ScheduleKind = "Scheduled"
         } elseif ($analyticRule.kind -eq "Nrt") {


### PR DESCRIPTION
This pull request introduces a small but important fix to the `Convert-SentinelARYamlToArm` function in `Convert-SentinelARYamlToArm.ps1`. The change ensures that escaped double quotes in the JSON output are properly converted, which helps prevent formatting issues when generating ARM templates.

* Fixed JSON formatting by replacing triple-escaped double quotes (`\\\\"`) with standard double quotes (`\"`) to ensure valid output.