### PR TITLE
Bump module version to 2.4.5

### DIFF
--- a/src/SentinelARConverter.psd1
+++ b/src/SentinelARConverter.psd1
@@ -12,7 +12,7 @@
     RootModule        = 'SentinelARConverter.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '2.4.4'
+    ModuleVersion     = '2.4.5'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()


### PR DESCRIPTION
This pull request updates the version number of the `SentinelARConverter` PowerShell module. No other changes are included.

* Bumped the `ModuleVersion` field in `src/SentinelARConverter.psd1` from `2.4.4` to `2.4.5`.