### PR TITLE
Revert recent JSON handling change

### DIFF
--- a/src/SentinelARConverter.psd1
+++ b/src/SentinelARConverter.psd1
@@ -12,7 +12,7 @@
     RootModule        = 'SentinelARConverter.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '2.4.6'
+    ModuleVersion     = '2.4.7'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/src/public/Convert-SentinelARYamlToArm.ps1
+++ b/src/public/Convert-SentinelARYamlToArm.ps1
@@ -417,8 +417,6 @@ function Convert-SentinelARYamlToArm {
         # Use ISO8601 format for timespan values
         $JSON = $JSON -replace '"([0-9]+)m"', '"PT$1M"' -replace '"([0-9]+)h"', '"PT$1H"' -replace '"([0-9]+)d"', '"P$1D"'
 
-        $JSON = $JSON -replace '\\\\\\\"', '\"'
-
         if ($analyticRule.kind -eq "Scheduled") {
             $ScheduleKind = "Scheduled"
         } elseif ($analyticRule.kind -eq "Nrt") {


### PR DESCRIPTION
This pull request makes a minor update to the module version in `SentinelARConverter.psd1`, incrementing it from 2.4.6 to 2.4.7. Additionally, it removes a redundant string replacement operation in the `Convert-SentinelARYamlToArm` function, likely as a cleanup or bug fix.

- Version update:
  * Updated the `ModuleVersion` field in `SentinelARConverter.psd1` from '2.4.6' to '2.4.7'.

- Code cleanup:
  * Removed an unnecessary string replacement (`$JSON = $JSON -replace '\\\\"', '\"'`) from the `Convert-SentinelARYamlToArm` function in `Convert-SentinelARYamlToArm.ps1`.